### PR TITLE
Changed wrong variable name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you want to redirect the user to two different URLs depending on the device t
 ```javascript
 	SA.redirection_mobile ({
 		mobile_url : "mobile.whatever.com",
-		tablet_url : "tablet.whatever.com",
+		tablet_host : "tablet.whatever.com",
 	});
 ```
 


### PR DESCRIPTION
Have changed the wrong variable name in example

From "tablet_url" to "tablet_host"

Here:
    SA.redirection_mobile ({
        mobile_url : "mobile.whatever.com",
        tablet_host : "tablet.whatever.com",
    });
